### PR TITLE
basic usage instruction docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pip install brainreg
 
 ### Basic usage
 ```bash
-brainreg /path/to/raw/data /path/to/output/directory -x 2 -y 2 -z 5
+brainreg /path/to/raw/data /path/to/output/directory -v 2 2 5 --orientation psl
 ```
 
 ## Arguments


### PR DESCRIPTION
I performed a fresh dev install and the basic usage instruction did not work because the syntax for inputting voxel sizes has changed and the orientation is required. I have modified the docs to reflect this