### PR TITLE
GUI alternative with Gooey

### DIFF
--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 import tempfile
 from argparse import (
@@ -178,6 +179,12 @@ def prep_registration(args):
             additional_images_downsample[name] = images
 
     return args, additional_images_downsample
+
+
+# The Gooey GUI needs to be explicitly disabled.
+# This needs to run before the @Gooey decorator is called.
+if '--gui' not in sys.argv:
+    sys.argv.append('--ignore-gooey')
 
 
 @Gooey(program_name='brainreg', default_size=(680, 630))

--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -76,7 +76,7 @@ def cli_parse(parser):
 
 
 def atlas_parse(parser):
-    atlas_parser = parser.add_argument_group("brainreg registration options")
+    atlas_parser = parser.add_argument_group("atlas options")
     atlas_parser.add_argument(
         "--atlas",
         dest="atlas",

--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -130,6 +130,14 @@ def misc_parse(parser):
         "sorted as would be expected by a human and "
         "not purely alphabetically",
     )
+
+    misc_parser.add_argument(
+        "--gui",
+        dest="gui",
+        action="store_true",
+        help="If enabled, launches a graphical user interface for running brainreg.",
+    )
+
     return parser
 
 

--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -18,6 +18,8 @@ from brainreg.backend.niftyreg.parser import niftyreg_parse
 import brainreg as program_for_log
 from brainreg.paths import Paths
 
+from gooey import Gooey
+
 
 temp_dir = tempfile.TemporaryDirectory()
 temp_dir_path = temp_dir.name
@@ -174,6 +176,7 @@ def prep_registration(args):
     return args, additional_images_downsample
 
 
+@Gooey
 def main():
     start_time = datetime.now()
     args = register_cli_parser().parse_args()

--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -18,7 +18,7 @@ from brainreg.backend.niftyreg.parser import niftyreg_parse
 import brainreg as program_for_log
 from brainreg.paths import Paths
 
-from gooey import Gooey
+from gooey import Gooey, GooeyParser
 
 
 temp_dir = tempfile.TemporaryDirectory()
@@ -26,7 +26,7 @@ temp_dir_path = temp_dir.name
 
 
 def register_cli_parser():
-    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+    parser = GooeyParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser = cli_parse(parser)
     parser = atlas_parse(parser)
     parser = backend_parse(parser)
@@ -46,12 +46,14 @@ def cli_parse(parser):
         type=str,
         help="Path to the directory of the image files. Can also be a text"
         "file pointing to the files.",
+        widget='FileChooser',
     )
 
     cli_parser.add_argument(
         dest="brainreg_directory",
         type=str,
         help="Directory to save the output",
+        widget='DirChooser',
     )
 
     cli_parser.add_argument(
@@ -62,6 +64,7 @@ def cli_parse(parser):
         nargs="+",
         help="Paths to N additional channels to downsample to the same "
         "coordinate space. ",
+        widget="MultiFileChooser",
     )
     cli_parser.add_argument(
         "--version",
@@ -106,6 +109,7 @@ def misc_parse(parser):
         default=4,
         help="The number of CPU cores on the machine to leave "
         "unused by the program to spare resources.",
+        widget="IntegerField",
     )
 
     misc_parser.add_argument(
@@ -176,7 +180,7 @@ def prep_registration(args):
     return args, additional_images_downsample
 
 
-@Gooey
+@Gooey(program_name='brainreg', default_size=(680, 630))
 def main():
     start_time = datetime.now()
     args = register_cli_parser().parse_args()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requirements = [
     "napari[pyside2]>=0.3.7",
     "brainglobe-napari-io",
     "brainreg-segment>=0.0.2",
+    "Gooey",
 ]
 
 


### PR DESCRIPTION
Hey folks,

First of all, many thanks for all the great work you've done with the brainglobe suite! 

I recently had to convert the CLI into a simple GUI for some less technically minded folk who like what brainreg does but don't like terminals. I'm aware that a GUI exists within napari, but as this was neither part of their workflow (nor something they were interested in switching to in this instance) I used the Gooey project (https://github.com/chriskiehl/Gooey) to wrap the command line version of brainreg into a straight-forward GUI (see screenshot below). This then allows folk who don't want to deal with the terminal to use brainreg as a stand-alone tool, without having to install (or learn) napari.

I appreciate this may not be something you want to support -- I open this PR in case you find it useful, or if you think the use case here is frequent enough to support.

![Here it is on MacOS (but works on Linux and Windows, where brainreg actually works)](https://user-images.githubusercontent.com/5901774/139108938-dc1cd1bd-db4d-4ffd-bb5b-cf9e0df91420.png)

All the best,
Constantinos
