### PR TITLE
add an option to save registered atlas with the same orientation as he input data

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ brainreg /path/to/raw/data /path/to/output/directory -v 5 2 2 --orientation psl
 
 * `--n-free-cpus` The number of CPU cores on the machine to leave unused by the program to spare resources.
 * `--debug` Debug mode. Will increase verbosity of logging and save all intermediate files for diagnosis of software issues.
+* `--save_original_orientation` Option to save the registered atlas with the same orientation as the input data.
 
 ### Atlas
 

--- a/brainreg/backend/niftyreg/run.py
+++ b/brainreg/backend/niftyreg/run.py
@@ -31,6 +31,7 @@ def run_niftyreg(
     sort_input_file,
     n_free_cpus,
     debug=False,
+    save_original_orientation=False,
 ):
 
     niftyreg_directory = os.path.join(registration_output_folder, "niftyreg")
@@ -108,6 +109,15 @@ def run_niftyreg(
         ),
         paths.registered_atlas,
     )
+
+    if save_original_orientation:
+        atlas = imio.load_any(niftyreg_paths.registered_atlas_path).astype(np.uint32, copy=False)
+        atlas_remaped = bg.map_stack_to(
+            ATLAS_ORIENTATION, DATA_ORIENTATION, atlas
+        ).astype(np.uint32, copy=False)
+        imio.to_tiff(atlas_remaped, paths.registered_atlas_original_orientation)
+
+
     imio.to_tiff(
         imio.load_any(niftyreg_paths.registered_hemispheres_img_path).astype(
             np.uint8, copy=False

--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -115,6 +115,13 @@ def misc_parse(parser):
     )
 
     misc_parser.add_argument(
+        "--save_original_orientation",
+        dest="save_original_orientation",
+        action="store_true",
+        help="Option to save the atlas annotations in the same orientation as the original data.",
+    )
+
+    misc_parser.add_argument(
         "--sort-input-file",
         dest="sort_input_file",
         action="store_true",
@@ -208,6 +215,7 @@ def main():
         additional_images_downsample=additional_images_downsample,
         backend=args.backend,
         debug=args.debug,
+        save_original_orientation=args.save_original_orientation,
     )
 
     logging.info("Finished. Total time taken: %s", datetime.now() - start_time)

--- a/brainreg/main.py
+++ b/brainreg/main.py
@@ -26,6 +26,7 @@ def main(
     backend="niftyreg",
     scaling_rounding_decimals=5,
     debug=False,
+    save_original_orientation=False,
 ):
     atlas = BrainGlobeAtlas(atlas)
     source_space = bg.AnatomicalSpace(data_orientation)
@@ -76,6 +77,7 @@ def main(
             sort_input_file,
             n_free_cpus,
             debug=debug,
+            save_original_orientation=save_original_orientation,
         )
 
     logging.info("Calculating volumes of each brain area")

--- a/brainreg/paths.py
+++ b/brainreg/paths.py
@@ -20,6 +20,7 @@ class Paths:
         self.boundaries_file_path = self.make_reg_path("boundaries.tiff")
 
         self.registered_atlas = self.make_reg_path("registered_atlas.tiff")
+        self.registered_atlas_original_orientation = self.make_reg_path("registered_atlas_original_orientation.tiff")
         self.registered_hemispheres = self.make_reg_path(
             "registered_hemispheres.tiff"
         )


### PR DESCRIPTION
I added an option --save_original_orientation

The flag is passed through the different functions and used in run_niftyreg. It just loads the registered atlas, map it using bg-space and save it back as tiff. I added the info in the readme but it might be worth adding it in the readthedoc also.

I modified the paths class to add the registered_atlas_original_orientation.

I try it on two datasets and it works fine.

PR to solve #40 