### PR TITLE
Cache downloaded brain atlas

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,6 +19,10 @@ jobs:
           - {os: "windows-latest", python-version: "3.7"}
           - {os: "windows-latest", python-version: "3.8"}
     steps:
+      - uses: actions/cache@v3
+        with:
+            path: ~/.brainglobe
+            key: atlases
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
I *think* this will speed up test runs quite significantly, as downloading the atlast from wherever it is hosted is relatively slow.