### PR TITLE
Don't specify QT backend in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
     "imio",
     "fancylog",
     "imlib>=0.0.26",
-    "napari[pyside2]>=0.3.7",
+    "napari>=0.3.7",
     "brainglobe-napari-io",
     "brainreg-segment>=0.0.2",
 ]


### PR DESCRIPTION
See https://napari.org/plugins/best_practices.html#don-t-include-pyside2-or-pyqt5-in-your-plugin-s-dependencies as to why this is not a good thing to do.