### PR TITLE
Revert "Don't specify QT backend in requirements"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "imio",
     "fancylog",
     "imlib>=0.0.26",
-    "napari>=0.3.7",
+    "napari[pyside2]>=0.3.7",
     "brainglobe-napari-io",
     "brainreg-segment>=0.0.2",
 ]


### PR DESCRIPTION
Reverts brainglobe/brainreg#73. As discussed with Adam on slack.