### PR TITLE
Changing -d --downsample flag to -a --additional

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ brainreg /path/to/raw/data /path/to/output/directory -v 5 2 2 --orientation psl
 
 ### Additional options
 
-* `-d` or `--downsample` Paths to N additional channels to downsample to the same coordinate space.
+* `-a` or `--additional` Paths to N additional channels to downsample to the same coordinate space.
 * `--sort-input-file` If set to true, the input text file will be sorted using natural sorting. This means that the file paths will be sorted as would be expected by a human and not purely alphabetically.
 * `--brain_geometry` Can be one of `full` (default) for full brain registration, `hemisphere_l` for left hemisphere data-set and `hemisphere_r` for right hemisphere data-set.
 

--- a/brainreg/cli.py
+++ b/brainreg/cli.py
@@ -49,9 +49,9 @@ def cli_parse(parser):
     )
 
     cli_parser.add_argument(
-        "-d",
-        "--downsample",
-        dest="downsample_images",
+        "-a",
+        "--additional",
+        dest="additional_images",
         type=str,
         nargs="+",
         help="Paths to N additional channels to downsample to the same "
@@ -181,8 +181,8 @@ def prep_registration(args):
     ensure_directory_exists(args.brainreg_directory)
 
     additional_images_downsample = {}
-    if args.downsample_images:
-        for idx, images in enumerate(args.downsample_images):
+    if args.additional_images:
+        for idx, images in enumerate(args.additional_images):
             name = Path(images).name
             additional_images_downsample[name] = images
 

--- a/tests/tests/test_integration/test_registration.py
+++ b/tests/tests/test_integration/test_registration.py
@@ -42,7 +42,7 @@ def whole_brain_output_path(tmp_path_factory):
         "0",
         "--atlas",
         "allen_mouse_100um",
-        "-d",
+        "-a",
         str(whole_brain_data_dir),
     ]
 


### PR DESCRIPTION
- changed -d -downsample arguments to -a -additional. Updated tests so all pass. Issue brainglobe/brainreg#84

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
Make the -d / --downsample argument clearer as it rather takes additional images to be processed.

**What does this PR do?**

changes -d and --downsample flags to -a and --additional

## References

Please reference any existing issues/PRs that relate to this PR.

Issue brainglobe/brainreg#84

## How has this PR been tested?

The flags in testing code (-d) was changed (to -a) and all tests ran.

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

All test passed after change

## Is this a breaking change?

no 

If this PR breaks any existing functionality, please explain how and why.

NA

## Does this PR require an update to the documentation?

Yes, the README.md was updated as part of the PR. The documentation at [here](https://docs.brainglobe.info/brainreg/user-guide) needs to be updated

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.



## Checklist:

- [X ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
