### PR TITLE
update setup.py for napari optional install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,11 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=requirements,
     extras_require={
-
         "napari": [
             "napari[pyside2]>=0.3.7",
             "brainglobe-napari-io",
             "brainreg-segment>=0.0.2",
         ],
-
         "dev": [
             "black",
             "pytest-cov",
@@ -44,7 +42,7 @@ setup(
             "bump2version",
             "pre-commit",
             "flake8",
-        ]
+        ],
     },
     python_requires=">=3.7",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ requirements = [
     "imio",
     "fancylog",
     "imlib>=0.0.26",
-    "napari[pyside2]>=0.3.7",
-    "brainglobe-napari-io",
-    "brainreg-segment>=0.0.2",
 ]
 
 
@@ -32,6 +29,13 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=requirements,
     extras_require={
+
+        "napari": [
+            "napari[pyside2]>=0.3.7",
+            "brainglobe-napari-io",
+            "brainreg-segment>=0.0.2",
+        ],
+
         "dev": [
             "black",
             "pytest-cov",


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

Fix issues with macOS install, M1 M2 chip and pyside2 by splitting imports to default (CLI tools only) and [napari] to cover GUI, including pyside2 #77

**What is this PR**

- [ X] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Brainreg fails on M1, M2 chips due to lack of upside build 

**What does this PR do?**

splits imports into CLI and napari

## References

Please reference any existing issues/PRs that relate to this PR.

#77

## How has this PR been tested?

tested with manual install

## Is this a breaking change?

No

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [ X] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
