### PR TITLE
removed version from napari dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "napari": [
-            "napari[pyside2]>=0.3.7",
+            "napari[pyside2]",
             "brainglobe-napari-io",
             "brainreg-segment>=0.0.2",
         ],


### PR DESCRIPTION
Removed outdated version dependency on pyside[napari], linked to #99 