### PR TITLE
Use standard pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-    - repo: https://github.com/pycqa/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:
@@ -15,13 +11,10 @@ repos:
             args: [--fix=lf]
           - id: requirements-txt-fixer
           - id: trailing-whitespace
-            # bump2version produces whitespace in setup.cfg, so exclude to
-            # not inferfere with versioning
-            exclude: setup.cfg
-    - repo: https://github.com/pycqa/flake8
-      rev: 6.0.0
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.240
       hooks:
-          - id: flake8
+        - id: ruff
     - repo: https://github.com/psf/black
       rev: 23.1.0
       hooks:
@@ -32,3 +25,4 @@ repos:
           - id: mypy
             additional_dependencies:
                 - types-setuptools
+                - types-requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,10 @@
 [tool.black]
+target-version = ['py38', 'py39', 'py310']
+skip-string-normalization = false
 line-length = 79
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
 
-
-[tool.isort]
-profile = "black"
-line_length = 79
+[tool.ruff]
+line-length = 79
+exclude = ["__init__.py","build",".eggs"]
+select = ["I", "E", "F"]
+fix = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,14 +4,14 @@ commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<rc>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{rc}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = rc
-values = 
+values =
 	rc
 	prod
 


### PR DESCRIPTION
This applies the standard pre-commit-config.yaml file from https://github.com/SainsburyWellcomeCentre/python-cookiecutter, and fixes files as needed for this new config.