### PR TITLE
Fix test data directory paths

### DIFF
--- a/tests/tests/test_integration/test_registration.py
+++ b/tests/tests/test_integration/test_registration.py
@@ -17,7 +17,7 @@ if platform.system() == "Darwin":
 else:
     test_dir = platform.system()
 
-test_data_dir = Path(os.getcwd()) / "tests" / "data"
+test_data_dir = Path(__file__).parent.parent.parent / "data"
 
 whole_brain_data_dir = test_data_dir / "input" / "brain"
 whole_brain_expected_output_dir = (

--- a/tests/tests/test_unit/test_exceptions.py
+++ b/tests/tests/test_unit/test_exceptions.py
@@ -7,7 +7,7 @@ import pytest
 from brainreg.cli import main as brainreg_run
 from brainreg.exceptions import LoadFileException
 
-test_data_dir = Path(os.getcwd()) / "tests" / "data"
+test_data_dir = Path(__file__).parent.parent.parent / "data"
 one_tiff_data_dir = test_data_dir / "input" / "exceptions" / "one_tiff"
 mismatched_dims_data_dir = (
     test_data_dir / "input" / "exceptions" / "mismatched_dims"


### PR DESCRIPTION
Previously the use of `getcwd()` prevented tests for being run in an arbitrary directory. Fix this by getting the directory relative to test files.