### PR TITLE
Clean up package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,11 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 requirements = [
     "bg-atlasapi",
     "bg-space",
-    "numpy",
-    "configparser",
-    "scikit-image",
-    "multiprocessing-logging",
-    "configobj",
-    "slurmio",
-    "imio",
     "fancylog",
+    "imio",
     "imlib>=0.0.26",
+    "numpy",
+    "scikit-image",
 ]
 
 

--- a/tests/tests/test_integration/test_registration.py
+++ b/tests/tests/test_integration/test_registration.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from brainreg.cli import main as brainreg_run
 
 from .utils import check_images_same, check_volumes_equal

--- a/tests/tests/test_unit/test_exceptions.py
+++ b/tests/tests/test_unit/test_exceptions.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from brainreg.cli import main as brainreg_run
 from brainreg.exceptions import LoadFileException
 


### PR DESCRIPTION
I noticed while putting `brainreg` on conda-forge that there's quite a few dependencies that don't seem to be needed. I've removed some that don't seem to be used, and cleaned up the remaining list in alphabetical order.