### PR TITLE
Add a test run installing niftyreg from conda

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,8 +19,10 @@ jobs:
         include:
         - os: ubuntu-latest
           python-version: "3.11"
+        # Run macos tests with niftyreg installed from conda
         - os: macos-latest
           python-version: "3.10"
+          tox-args: "-e py310-conda"
         - os: windows-latest
           python-version: "3.9"
         - os: ubuntu-latest
@@ -34,6 +36,7 @@ jobs:
       - uses: neuroinformatics-unit/actions/test@v1
         with:
           python-version: ${{ matrix.python-version }}
+          tox-args: ${{ matrix.tox-args }}
 
   deploy:
     needs: test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{38,39,310,311}
+envlist = py{38,39,310,311}{,-conda}
+requires = tox-conda
+isolated_build = true
 
 [gh-actions]
 python =
@@ -13,3 +15,9 @@ extras =
     dev
 commands =
     pytest -v --color=yes --cov=brainreg --cov-report=xml
+
+[testenv:py{38,39,310,311}-conda]
+conda_deps=
+    niftyreg
+conda_channels=
+    conda-forge


### PR DESCRIPTION
This adds a test run where `niftyreg` is installed from conda. This should show up as an increase in test coverage for the code that detects and uses the niftyreg binaries isntalled by conda.

Fixes https://github.com/brainglobe/brainreg/issues/74.