### PR TITLE
Update with brainreg-segment rename to brainglobe-segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation for both the command-line tool and graphical interface can be foun
 If you have any issues, please get in touch [on the forum](https://forum.image.sc/tag/brainglobe), [on Zulip](https://brainglobe.zulipchat.com/), or by
 [raising an issue](https://github.com/brainglobe/brainreg/issues).
 
-For segmentation of bulk structures in 3D space (e.g. injection sites, Neuropixels probes), please see [brainreg-segment](https://github.com/brainglobe/brainreg-segment).
+For segmentation of bulk structures in 3D space (e.g. injection sites, Neuropixels probes), please see [brainglobe-segmentation](https://github.com/brainglobe/brainglobe-segmentation).
 
 ## Details
 

--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -10,7 +10,7 @@ import napari
 import numpy as np
 from bg_atlasapi import BrainGlobeAtlas
 from brainglobe_napari_io.cellfinder.reader_dir import load_registration
-from brainreg_segment.atlas.utils import get_available_atlases
+from brainglobe_segmentation.atlas.utils import get_available_atlases
 from fancylog import fancylog
 from magicgui import magicgui
 from napari._qt.qthreading import thread_worker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 napari = [
     "brainglobe-napari-io",
-    "brainreg-segment",
+    "brainglobe-segment >= 1.0.0",
     "magicgui",
     "napari-plugin-engine >= 0.1.4",
     "napari[pyqt5]",


### PR DESCRIPTION
Updates the `brainreg-segment` dependency to be consistent with https://github.com/brainglobe/brainreg-segment/pull/139.

NOTE: CI will fail until the aforementioned PR is merged and a new PyPI version is published.