### PR TITLE
Add napari trove classifier to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Framework :: napari",
 ]
 requires-python = ">=3.9"
 dependencies = [
@@ -37,7 +38,7 @@ napari = [
     "magicgui",
     "napari-plugin-engine >= 0.1.4",
     "napari[pyqt5]",
-    "pooch>1",                       # For sample data
+    "pooch>1",                          # For sample data
     "qtpy",
 ]
 dev = [


### PR DESCRIPTION
Closes #167 |

`napari` might fetch metadata from PyPI, so just to be safe we should publish a patch release after we merge this.