### PR TITLE
Update brainglobe-napari-io import

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -10,7 +10,7 @@ import napari
 import numpy as np
 from bg_atlasapi import BrainGlobeAtlas
 from bg_atlasapi.list_atlases import descriptors, utils
-from brainglobe_napari_io.workflows.wholebrain_cell_reader_dir import (
+from brainglobe_napari_io.brainmapper.brainmapper_reader_dir import (
     load_registration,
 )
 from fancylog import fancylog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 napari = [
-    "brainglobe-napari-io",
+    "brainglobe-napari-io >=0.3.2",
     "brainglobe-segmentation >= 1.0.0",
     "magicgui",
     "napari-plugin-engine >= 0.1.4",


### PR DESCRIPTION
Requires https://github.com/brainglobe/brainglobe-napari-io/pull/61 to be merged (tests will fail until it's released), and when a new version is released, it will need to pin the latest version of `brainglobe-napari-io`. 