### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,9 @@ requires-python = ">=3.9"
 dependencies = [
     "bg-atlasapi",
     "bg-space",
-    "brainglobe-utils",
+    "brainglobe-utils>=0.2.7",
     "fancylog",
     "imio",
-    "brainglobe-utils>=0.2.7",
     "numpy",
     "scikit-image",
 ]


### PR DESCRIPTION
For whatever reason we were listing `brainglobe-utils` twice in our pyproject.toml, once with a min version and once without. Small patch to correct that and remove redundancies.