### PR TITLE
Update `imio` dependency

### DIFF
--- a/brainreg/core/backend/niftyreg/run.py
+++ b/brainreg/core/backend/niftyreg/run.py
@@ -3,11 +3,11 @@ import os
 from pathlib import Path
 
 import brainglobe_space as bg
-import imio
 import numpy as np
 from bg_atlasapi import BrainGlobeAtlas
 from brainglobe_utils.general.system import delete_directory_contents
 from brainglobe_utils.image.scale import scale_and_convert_to_16_bits
+from brainglobe_utils.image_io import load_any, to_tiff
 
 from brainreg.core.backend.niftyreg.parameters import RegistrationParams
 from brainreg.core.backend.niftyreg.paths import NiftyRegPaths
@@ -72,7 +72,7 @@ def run_niftyreg(
     save_nii(reference, atlas.resolution, niftyreg_paths.brain_filtered)
     save_nii(target_brain, atlas.resolution, niftyreg_paths.downsampled_brain)
 
-    imio.to_tiff(
+    to_tiff(
         scale_and_convert_to_16_bits(target_brain),
         paths.downsampled_brain_path,
     )
@@ -125,32 +125,30 @@ def run_niftyreg(
     brain_reg.generate_deformation_field(niftyreg_paths.deformation_field)
 
     logging.info("Exporting images as tiff")
-    imio.to_tiff(
-        imio.load_any(niftyreg_paths.registered_atlas_path).astype(
+    to_tiff(
+        load_any(niftyreg_paths.registered_atlas_path).astype(
             np.uint32, copy=False
         ),
         paths.registered_atlas,
     )
 
     if save_original_orientation:
-        registered_atlas = imio.load_any(
+        registered_atlas = load_any(
             niftyreg_paths.registered_atlas_path
         ).astype(np.uint32, copy=False)
         atlas_remapped = bg.map_stack_to(
             ATLAS_ORIENTATION, DATA_ORIENTATION, registered_atlas
         ).astype(np.uint32, copy=False)
-        imio.to_tiff(
-            atlas_remapped, paths.registered_atlas_original_orientation
-        )
+        to_tiff(atlas_remapped, paths.registered_atlas_original_orientation)
 
-    imio.to_tiff(
-        imio.load_any(niftyreg_paths.registered_hemispheres_img_path).astype(
+    to_tiff(
+        load_any(niftyreg_paths.registered_hemispheres_img_path).astype(
             np.uint8, copy=False
         ),
         paths.registered_hemispheres,
     )
-    imio.to_tiff(
-        imio.load_any(niftyreg_paths.downsampled_brain_standard_space).astype(
+    to_tiff(
+        load_any(niftyreg_paths.downsampled_brain_standard_space).astype(
             np.uint16, copy=False
         ),
         paths.downsampled_brain_standard_space,
@@ -159,16 +157,16 @@ def run_niftyreg(
     del reference
     del target_brain
 
-    deformation_image = imio.load_any(niftyreg_paths.deformation_field)
-    imio.to_tiff(
+    deformation_image = load_any(niftyreg_paths.deformation_field)
+    to_tiff(
         deformation_image[..., 0, 0].astype(np.float32, copy=False),
         paths.deformation_field_0,
     )
-    imio.to_tiff(
+    to_tiff(
         deformation_image[..., 0, 1].astype(np.float32, copy=False),
         paths.deformation_field_1,
     )
-    imio.to_tiff(
+    to_tiff(
         deformation_image[..., 0, 2].astype(np.float32, copy=False),
         paths.deformation_field_2,
     )
@@ -201,7 +199,7 @@ def run_niftyreg(
             )
 
             # do the tiff part at the beginning
-            downsampled_brain = imio.load_any(
+            downsampled_brain = load_any(
                 filename,
                 scaling[1],
                 scaling[2],
@@ -219,7 +217,7 @@ def run_niftyreg(
                 downsampled_brain, atlas.resolution, tmp_downsampled_brain_path
             )
 
-            imio.to_tiff(downsampled_brain, downsampled_brain_path)
+            to_tiff(downsampled_brain, downsampled_brain_path)
 
             logging.info("Transforming to standard space")
 
@@ -227,8 +225,8 @@ def run_niftyreg(
                 tmp_downsampled_brain_path, tmp_downsampled_brain_standard_path
             )
 
-            imio.to_tiff(
-                imio.load_any(tmp_downsampled_brain_standard_path).astype(
+            to_tiff(
+                load_any(tmp_downsampled_brain_standard_path).astype(
                     np.uint16, copy=False
                 ),
                 downsampled_brain_standard_path,

--- a/brainreg/core/backend/niftyreg/utils.py
+++ b/brainreg/core/backend/niftyreg/utils.py
@@ -1,5 +1,6 @@
-import imio
 import numpy as np
+
+from brainglobe_utils.image_io import to_nii
 
 
 def save_nii(stack, atlas_pixel_sizes, dest_path):
@@ -11,7 +12,7 @@ def save_nii(stack, atlas_pixel_sizes, dest_path):
     :param str dest_path: Where to save the image on the filesystem
     """
     transformation_matrix = get_transf_matrix_from_res(atlas_pixel_sizes)
-    imio.to_nii(
+    to_nii(
         stack,
         dest_path,
         scale=(

--- a/brainreg/core/exceptions.py
+++ b/brainreg/core/exceptions.py
@@ -32,7 +32,7 @@ def search_dir_for_image_files(target_brain_path):
 class LoadFileException(Exception):
     """
     Custom exception class for errors found loading image with
-    imio.load_any (in main.py).
+    brainglobe_utils.image_io.load_any (in main.py).
 
     If the passed target brain directory contains only a single
     .tiff, alert the user.
@@ -58,8 +58,9 @@ class LoadFileException(Exception):
             )
             self.message = (
                 f"{origional_traceback}\nFile failed to load with "
-                f"imio. Ensure all image files contain the "
-                f"same number of pixels. Full traceback above."
+                "brainglobe_utils.image_io. "
+                "Ensure all image files contain the "
+                "same number of pixels. Full traceback above."
             )
 
         super().__init__(self.message)

--- a/brainreg/core/main.py
+++ b/brainreg/core/main.py
@@ -1,9 +1,9 @@
 import logging
 
 import brainglobe_space as bg
-import imio
 from bg_atlasapi import BrainGlobeAtlas
 from brainglobe_utils.general.system import get_num_processes
+from brainglobe_utils.image_io import load_any
 
 from brainreg.core.backend.niftyreg.run import run_niftyreg
 from brainreg.core.exceptions import (
@@ -55,7 +55,7 @@ def main(
     logging.info("Loading raw image data")
 
     try:
-        target_brain = imio.load_any(
+        target_brain = load_any(
             target_brain_path,
             scaling[1],
             scaling[2],

--- a/brainreg/core/utils/boundaries.py
+++ b/brainreg/core/utils/boundaries.py
@@ -1,8 +1,9 @@
 import logging
 
-import imio
 import numpy as np
 from skimage.segmentation import find_boundaries
+
+from brainglobe_utils.image_io import load_any, to_tiff
 
 
 def boundaries(registered_atlas, boundaries_out_path):
@@ -14,9 +15,9 @@ def boundaries(registered_atlas, boundaries_out_path):
     :param registered_atlas: The registered atlas
     :param boundaries_out_path: Path to save the boundary image
     """
-    atlas_img = imio.load_any(registered_atlas)
+    atlas_img = load_any(registered_atlas)
     boundaries_image = find_boundaries(atlas_img, mode="inner").astype(
         np.int8, copy=False
     )
     logging.debug("Saving segmentation boundary image")
-    imio.to_tiff(boundaries_image, boundaries_out_path)
+    to_tiff(boundaries_image, boundaries_out_path)

--- a/brainreg/core/utils/volume.py
+++ b/brainreg/core/utils/volume.py
@@ -7,9 +7,10 @@ Module to calculate volume of brain regions
 
 import logging
 
-import imio
 import numpy as np
 import pandas as pd
+
+from brainglobe_utils.image_io import load_any
 from brainglobe_utils.pandas.misc import initialise_df, safe_pandas_concat
 
 
@@ -41,8 +42,8 @@ def get_lateralised_atlas(
     left_hemisphere_value=2,
     right_hemisphere_value=1,
 ):
-    atlas = imio.load_any(atlas_path)
-    hemispheres = imio.load_any(hemispheres_path)
+    atlas = load_any(atlas_path)
+    hemispheres = load_any(hemispheres_path)
 
     atlas_left, atlas_right = lateralise_atlas(
         atlas,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,8 @@ requires-python = ">=3.9"
 dependencies = [
     "bg-atlasapi",
     "brainglobe-space>=1.0.0",
-    "brainglobe-utils>=0.2.7",
+    "brainglobe-utils>=0.4.0",
     "fancylog",
-    "imio",
     "numpy",
     "scikit-image",
 ]

--- a/tests/tests/test_integration/utils.py
+++ b/tests/tests/test_integration/utils.py
@@ -2,7 +2,8 @@ import os
 
 import numpy as np
 import pandas as pd
-from imio.load import load_any
+
+from brainglobe_utils.image_io import load_any
 
 relative_tolerance = 0.01
 absolute_tolerance = 10

--- a/tests/tests/test_unit/test_exceptions.py
+++ b/tests/tests/test_unit/test_exceptions.py
@@ -49,8 +49,8 @@ def test_mismatched_dims_error(test_output_dir):
         brainreg_run()
 
     assert (
-        "File failed to load with "
-        "imio. Ensure all image files contain the "
+        "File failed to load with brainglobe_utils.image_io. "
+        "Ensure all image files contain the "
         "same number of pixels. Full traceback above." in e.value.message
     )
 


### PR DESCRIPTION
As per https://github.com/brainglobe/BrainGlobe/issues/64

`imio` is merging with `brainglobe-utils` version 0.4.0, so we should drop our `imio` dependency and instead use the version that comes with `brainglobe-utils`.

CI will fail until `brainglobe-utils v0.4.0` is available on PyPI. 