### PR TITLE
allow for additional channels with same name

### DIFF
--- a/brainreg/core/cli.py
+++ b/brainreg/core/cli.py
@@ -219,24 +219,24 @@ def prep_registration(args):
     logging.debug("Making registration directory")
     ensure_directory_exists(args.brainreg_directory)
 
-    additional_images_downsample = {}
+    additional_images_to_downsample = {}
 
     if args.additional_images:
-        file_names = [Path(path).name for path in args.additional_images]
-        has_duplicates = any(file_names.count(name) > 1 for name in file_names)  
-        for images in args.additional_images:
-            channel_name = Path(images).name
-            if not has_duplicates:
-                additional_images_downsample[channel_name] = images
+        path_names = [Path(path).name for path in args.additional_images] #could be files or folders containing e.g. lots of 2D tiffs
+        has_duplicate_names = any(path_names.count(name) > 1 for name in path_names)  
+        for additional_channel_paths in args.additional_images:
+            channel_name = Path(additional_channel_paths).name
+            if not has_duplicate_names:
+                additional_images_to_downsample[channel_name] = additional_channel_paths
             else:
-                channel_name = Path(images).name
-                parent_folder = Path(images).parent.name
+                channel_name = Path(additional_channel_paths).name
+                parent_folder = Path(additional_channel_paths).parent.name
                 channel_name = f"{parent_folder}_{channel_name}"
-                additional_images_downsample[channel_name] = images
+                additional_images_to_downsample[channel_name] = additional_channel_paths
 
-        assert len(args.additional_images) == len(additional_images_downsample), "Something went wrong parsing additional channel names - please ensure additional channels have a unique combination of name and parent folder."
+        assert len(args.additional_images) == len(additional_images_to_downsample), "Something went wrong parsing additional channel names - please ensure additional channels have a unique combination of name and parent folder."
 
-    return args, additional_images_downsample
+    return args, additional_images_to_downsample
 
 
 def main():

--- a/brainreg/core/cli.py
+++ b/brainreg/core/cli.py
@@ -254,9 +254,11 @@ def prep_registration(args):
 
         assert len(args.additional_images) == len(
             additional_images_to_downsample
-        ), "Something went wrong parsing additional channel names - \
-        please ensure additional channels have a unique \
-        combination of name and parent folder."
+        ), (
+            "Something went wrong parsing additional channel names - "
+            + "please ensure additional channels have a unique "
+            + "combination of name and parent folder."
+        )
 
     return args, additional_images_to_downsample
 

--- a/brainreg/core/cli.py
+++ b/brainreg/core/cli.py
@@ -201,19 +201,29 @@ def prep_registration(args):
     Prepares the file system for registration.
 
     Ensures the brainreg directory exists and
-    computes the file names for additional channels
-    that should be registered (if any were passed).
+    stores paths for additional channels
+    that should be registered (if any were passed)
+    into a dictionary.
 
-    Filenames for additional channels are 
-    * the file/folder name passed (if unique for all additional channels)
-    * the file/folder name prefixed with the parent folder name (otherwise)
+    Dictionary keys for additional channel paths are
+    - the file/folder name passed (if unique for all additional channels)
+    - the file/folder name prefixed with the parent folder name (otherwise)
 
     Throws an error if multiple additional channels have
-    the same name and the same parent folder.
+    the same name and the same parent folder, because the dictionary
+    key is not unique in this situation.
 
-    Parameters: 
-        args: ArgParse object. Expected attributes here are "brainreg_directory"
+    Parameters
+    ----------
+    args : argparse.Namespace
+        ArgParse object. Expected attributes here are "brainreg_directory"
         and (optionally) "additional_images".
+
+    Returns
+    -------
+    tuple
+        A tuple containing the `args` object
+        and the `additional_images_to_downsample` dictionary.
 
     """
     logging.debug("Making registration directory")
@@ -222,19 +232,31 @@ def prep_registration(args):
     additional_images_to_downsample = {}
 
     if args.additional_images:
-        path_names = [Path(path).name for path in args.additional_images] #could be files or folders containing e.g. lots of 2D tiffs
-        has_duplicate_names = any(path_names.count(name) > 1 for name in path_names)  
+        path_names = [
+            Path(path).name for path in args.additional_images
+        ]  # could be files or folders containing e.g. lots of 2D tiffs
+        has_duplicate_names = any(
+            path_names.count(name) > 1 for name in path_names
+        )
         for additional_channel_paths in args.additional_images:
             channel_name = Path(additional_channel_paths).name
             if not has_duplicate_names:
-                additional_images_to_downsample[channel_name] = additional_channel_paths
+                additional_images_to_downsample[channel_name] = (
+                    additional_channel_paths
+                )
             else:
                 channel_name = Path(additional_channel_paths).name
                 parent_folder = Path(additional_channel_paths).parent.name
                 channel_name = f"{parent_folder}_{channel_name}"
-                additional_images_to_downsample[channel_name] = additional_channel_paths
+                additional_images_to_downsample[channel_name] = (
+                    additional_channel_paths
+                )
 
-        assert len(args.additional_images) == len(additional_images_to_downsample), "Something went wrong parsing additional channel names - please ensure additional channels have a unique combination of name and parent folder."
+        assert len(args.additional_images) == len(
+            additional_images_to_downsample
+        ), "Something went wrong parsing additional channel names - \
+        please ensure additional channels have a unique \
+        combination of name and parent folder."
 
     return args, additional_images_to_downsample
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pre-commit",
     "pytest-cov",
     "pytest-qt",
+    "pytest-mock",
     "pytest",
     "setuptools_scm",
     "tox",

--- a/tests/tests/test_unit/test_cli.py
+++ b/tests/tests/test_unit/test_cli.py
@@ -1,36 +1,51 @@
-from brainreg.core.cli import prep_registration
 from pathlib import Path
+
 import pytest
+
+from brainreg.core.cli import prep_registration
+
 
 def test_prep_registration_different_names(mocker):
     """Check that additional channel names are returned, when unique."""
     args = mocker.Mock()
-    args.brainreg_directory=Path.home()  # This just needs to exist
-    args.additional_images=[Path.home()/"additional_channel_0", Path.home()/"additional_channel_1"]
-    
+    args.brainreg_directory = Path.home()  # This just needs to exist
+    args.additional_images = [
+        Path.home() / "additional_channel_0",
+        Path.home() / "additional_channel_1",
+    ]
+
     _, additional_channel_outputs = prep_registration(args)
     assert "additional_channel_0" in additional_channel_outputs
     assert "additional_channel_1" in additional_channel_outputs
-    
+
 
 def test_additional_channels_same_name_different_parent_name(mocker):
     """
     Check that parent folder name returned if additional channel names are not unique.
     """
     args = mocker.Mock()
-    args.brainreg_directory=Path.home()  # This just needs to exist
-    args.additional_images=[Path.home()/"folder_0/duplicate_name", Path.home()/"folder_1/duplicate_name"]
-    
+    args.brainreg_directory = Path.home()  # This just needs to exist
+    args.additional_images = [
+        Path.home() / "folder_0/duplicate_name",
+        Path.home() / "folder_1/duplicate_name",
+    ]
+
     _, additional_channel_outputs = prep_registration(args)
     assert "folder_1_duplicate_name" in additional_channel_outputs
     assert "folder_1_duplicate_name" in additional_channel_outputs
-    
+
 
 def test_prep_registration_same_name_same_parent_name(mocker):
     """Check that error is thrown if both parent and additional channel name are non-unique."""
     args = mocker.Mock()
-    args.brainreg_directory=Path.home()  # This just needs to exist
-    args.additional_images=[str(Path.home()/"duplicate_name"), str(Path.home()/"duplicate_name")]
-    
-    with pytest.raises(AssertionError, match=".*ensure additional channels have a unique combination of name and parent folder.*"):
+    args.brainreg_directory = Path.home()  # This just needs to exist
+    args.additional_images = [
+        str(Path.home() / "duplicate_name"),
+        str(Path.home() / "duplicate_name"),
+    ]
+
+    with pytest.raises(
+        AssertionError,
+        match=".*ensure additional channels have a unique combination of name and parent folder.*",
+    ):
         prep_registration(args)

--- a/tests/tests/test_unit/test_cli.py
+++ b/tests/tests/test_unit/test_cli.py
@@ -21,7 +21,8 @@ def test_prep_registration_different_names(mocker):
 
 def test_additional_channels_same_name_different_parent_name(mocker):
     """
-    Check that parent folder name returned if additional channel names are not unique.
+    Check that parent folder name is part of keys returned
+    if additional channel names are not unique.
     """
     args = mocker.Mock()
     args.brainreg_directory = Path.home()  # This just needs to exist
@@ -31,12 +32,14 @@ def test_additional_channels_same_name_different_parent_name(mocker):
     ]
 
     _, additional_channel_outputs = prep_registration(args)
-    assert "folder_1_duplicate_name" in additional_channel_outputs
-    assert "folder_1_duplicate_name" in additional_channel_outputs
+    assert "folder_1_duplicate_name" in additional_channel_outputs.keys()
+    assert "folder_1_duplicate_name" in additional_channel_outputs.keys()
 
 
 def test_prep_registration_same_name_same_parent_name(mocker):
-    """Check that error is thrown if both parent and additional channel name are non-unique."""
+    """Check that error is thrown if both
+    parent and additional channel name are non-unique.
+    """
     args = mocker.Mock()
     args.brainreg_directory = Path.home()  # This just needs to exist
     args.additional_images = [
@@ -46,6 +49,7 @@ def test_prep_registration_same_name_same_parent_name(mocker):
 
     with pytest.raises(
         AssertionError,
-        match=".*ensure additional channels have a unique combination of name and parent folder.*",
+        match=".*ensure additional channels have a unique "
+        + "combination of name and parent folder.*",
     ):
         prep_registration(args)

--- a/tests/tests/test_unit/test_cli.py
+++ b/tests/tests/test_unit/test_cli.py
@@ -1,0 +1,36 @@
+from brainreg.core.cli import prep_registration
+from pathlib import Path
+import pytest
+
+def test_prep_registration_different_names(mocker):
+    """Check that additional channel names are returned, when unique."""
+    args = mocker.Mock()
+    args.brainreg_directory=Path.home()  # This just needs to exist
+    args.additional_images=[Path.home()/"additional_channel_0", Path.home()/"additional_channel_1"]
+    
+    _, additional_channel_outputs = prep_registration(args)
+    assert "additional_channel_0" in additional_channel_outputs
+    assert "additional_channel_1" in additional_channel_outputs
+    
+
+def test_additional_channels_same_name_different_parent_name(mocker):
+    """
+    Check that parent folder name returned if additional channel names are not unique.
+    """
+    args = mocker.Mock()
+    args.brainreg_directory=Path.home()  # This just needs to exist
+    args.additional_images=[Path.home()/"folder_0/duplicate_name", Path.home()/"folder_1/duplicate_name"]
+    
+    _, additional_channel_outputs = prep_registration(args)
+    assert "folder_1_duplicate_name" in additional_channel_outputs
+    assert "folder_1_duplicate_name" in additional_channel_outputs
+    
+
+def test_prep_registration_same_name_same_parent_name(mocker):
+    """Check that error is thrown if both parent and additional channel name are non-unique."""
+    args = mocker.Mock()
+    args.brainreg_directory=Path.home()  # This just needs to exist
+    args.additional_images=[str(Path.home()/"duplicate_name"), str(Path.home()/"duplicate_name")]
+    
+    with pytest.raises(AssertionError, match=".*ensure additional channels have a unique combination of name and parent folder.*"):
+        prep_registration(args)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Folders/files containing additional channels to register currently can't have the same name.
Registered additional channels get overwritten.

**What does this PR do?**
Allows users to pass additional channel folder/file with the same name.
The files that will be written will be the first unique set of names going up the levels of the file tree.
This means that the current behaviour is preserved for unique sets of additional channel names.

This PRs also adds tests for this, and sensible error raising if you pass the same additional channel multiple times.
This PR also adds a docstring to the `prep_registration` function.

## References

Closes #183 

## How has this PR been tested?

New tests added.
Manual checking on real life data shows that for two additional channel tiff files with same names but in different folders (`025_micron/same_file_name.tif` and `025_micron_dummy/same_file_name.tif`, the files are named after the folders:
![image](https://github.com/brainglobe/brainreg/assets/10500965/206c41a6-f9a4-4655-9092-d2cd979641fb)

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Docstring added/updated.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
