### PR TITLE
Import header from brainglobe-utils

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -13,11 +13,13 @@ from brainglobe_atlasapi.list_atlases import descriptors, utils
 from brainglobe_napari_io.brainmapper.brainmapper_reader_dir import (
     load_registration,
 )
+from brainglobe_utils.qtpy.logo import header_widget
 from fancylog import fancylog
 from magicgui import magicgui
 from napari._qt.qthreading import thread_worker
 from napari.types import LayerDataTuple
 from napari.utils.notifications import show_info
+from PyQt5.QtWidgets import QScrollArea
 
 import brainreg as program_for_log
 from brainreg.core.backend.niftyreg.run import run_niftyreg
@@ -218,6 +220,7 @@ def brainreg_register():
         check_orientation_button=dict(
             widget_type="PushButton", text="Check orientation"
         ),
+        scrollable=True,
     )
     def widget(
         viewer: napari.Viewer,
@@ -593,5 +596,20 @@ def brainreg_register():
             name="Input proj. 2",
             scale=[s1, s2],
         )
+
+    widget.native.layout().insertWidget(
+        0,
+        header_widget(
+            "brainreg",
+            "Automated 3D brain registration",
+            tutorial_file_name="tutorial-whole-brain-registration.html",
+            citation_doi="https://doi.org/10.1038/s41598-021-04676-9",
+            help_text="For help, hover the cursor over each parameter.",
+        ),
+    )
+
+    scroll = QScrollArea()
+    scroll.setWidget(widget._widget._qwidget)
+    widget._widget._qwidget = scroll
 
     return widget

--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -19,7 +19,7 @@ from magicgui import magicgui
 from napari._qt.qthreading import thread_worker
 from napari.types import LayerDataTuple
 from napari.utils.notifications import show_info
-from PyQt5.QtWidgets import QScrollArea
+from qtpy.QtWidgets import QScrollArea
 
 import brainreg as program_for_log
 from brainreg.core.backend.niftyreg.run import run_niftyreg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.9"
 dependencies = [
     "brainglobe-atlasapi>=2.0.1",
     "brainglobe-space>=1.0.0",
-    "brainglobe-utils>=0.4.2",
+    "brainglobe-utils>=0.4.3",
     "fancylog",
     "numpy",
     "scikit-image",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
Currently, the `brainreg` widget has no header (i.e. no brainglobe logo / documentation links...).

**What does this PR do?**
This PR adds a header from `brainglobe-utils`. As this increases the length of an already long widget, a vertical scrollbar is also added to make navigation easier. This uses the same `QScrollArea` solution as the `cellfinder` [detect](https://github.com/brainglobe/cellfinder/blob/main/cellfinder/napari/detect/detect.py#L229) and [train](https://github.com/brainglobe/cellfinder/blob/main/cellfinder/napari/train/train.py#L180) widgets. These scrollbars aren't ideal as they require using internal (marked with `_`) values from the `magicgui` widget. A better solution would be to change all widgets to use `qtpy` directly, but this isn't a very quick fix.
![Screenshot 2024-04-15 113356](https://github.com/brainglobe/brainreg/assets/24316371/49e38f42-2c51-45b3-879a-61d833eb8ce2)

## References

For https://github.com/brainglobe/cellfinder/issues/327

## How has this PR been tested?

All tests pass locally.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
