### PR TITLE
CI on both types of Macs

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -35,7 +35,6 @@ jobs:
           python-version: "3.10"
         - os: macos-latest # ARM Mac
           python-version: "3.10"
-
         - os: windows-latest
           python-version: "3.9"
 
@@ -45,6 +44,10 @@ jobs:
         with:
             path: ~/.brainglobe
             key: atlases
+
+      - name: Install HDF5 on Mac
+        if: matrix.os == 'macos-latest'
+        run: brew install hdf5
 
       - name: Setup QT libraries
         uses: tlambert03/setup-qt-libs@v1

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -59,7 +59,10 @@ jobs:
           activate-environment: brainreg-env
       - name: Install niftyreg via conda on Apple Silicon
         if: matrix.os == 'macos-latest'
-        run: conda install niftyreg
+        run: |
+          which python
+          conda install niftyreg
+          conda install libpng
 
       - name: Setup QT libraries
         uses: tlambert03/setup-qt-libs@v1

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -49,6 +49,18 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install hdf5
 
+      - name: Set up Conda on Apple Silicon
+        if: matrix.os == 'macos-latest'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          channels: conda-forge
+          activate-environment: brainreg-env
+      - name: Install niftyreg via conda on Apple Silicon
+        if: matrix.os == 'macos-latest'
+        run: conda install niftyreg
+
       - name: Setup QT libraries
         uses: tlambert03/setup-qt-libs@v1
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,8 +31,11 @@ jobs:
         include:
         - os: ubuntu-latest
           python-version: "3.11"
-        - os: macos-latest
+        - os: macos-13 # Intel Mac
           python-version: "3.10"
+        - os: macos-latest # ARM Mac
+          python-version: "3.10"
+
         - os: windows-latest
           python-version: "3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
+requires = tox-conda
 envlist = py{38,39,310,311}
 isolated_build = True
 
@@ -109,6 +110,10 @@ python =
     3.11: py311
 
 [testenv]
+conda_deps =
+    niftyreg
+conda_channels =
+    conda-forge
 extras =
     dev
     napari


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We'd like to run CI on both Intel and Silicon Macs.

**What does this PR do?**

This PR modifies the workflow file so that test and installation runs smoothly on both Mac architectures.

## References
Partial solution to https://github.com/brainglobe/BrainGlobe/issues/63

## How has this PR been tested?

CI runs observed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
