### PR TITLE
Harmonise napari plugin and CLI entry points

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -201,12 +201,12 @@ def brainreg_register():
         smoothing_sigma_reference=dict(
             value=DEFAULT_PARAMETERS["smoothing_sigma_reference"],
             label="smoothing_sigma_reference",
-            min=-99,
+            min=-99.0,
         ),
         smoothing_sigma_floating=dict(
             value=DEFAULT_PARAMETERS["smoothing_sigma_floating"],
             label="smoothing_sigma_floating",
-            min=-99,
+            min=-99.0,
         ),
         histogram_n_bins_floating=dict(
             value=DEFAULT_PARAMETERS["histogram_n_bins_floating"],

--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -194,15 +194,19 @@ def brainreg_register():
             label="bending_energy_weight",
         ),
         grid_spacing=dict(
-            value=DEFAULT_PARAMETERS["grid_spacing"], label="grid_spacing"
+            value=DEFAULT_PARAMETERS["grid_spacing"],
+            label="grid_spacing",
+            min=-100,
         ),
         smoothing_sigma_reference=dict(
             value=DEFAULT_PARAMETERS["smoothing_sigma_reference"],
             label="smoothing_sigma_reference",
+            min=-99,
         ),
         smoothing_sigma_floating=dict(
             value=DEFAULT_PARAMETERS["smoothing_sigma_floating"],
             label="smoothing_sigma_floating",
+            min=-99,
         ),
         histogram_n_bins_floating=dict(
             value=DEFAULT_PARAMETERS["histogram_n_bins_floating"],

--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -127,9 +127,9 @@ def brainreg_register():
         freeform_n_steps=6,
         freeform_use_n_steps=4,
         bending_energy_weight=0.95,
-        grid_spacing=10,
-        smoothing_sigma_reference=1,
-        smoothing_sigma_floating=1,
+        grid_spacing=-10,
+        smoothing_sigma_reference=-1.0,
+        smoothing_sigma_floating=-1.0,
         histogram_n_bins_floating=128,
         histogram_n_bins_reference=128,
         debug=False,
@@ -239,10 +239,10 @@ def brainreg_register():
         freeform_use_n_steps: int,
         bending_energy_weight: float,
         grid_spacing: int,
-        smoothing_sigma_reference: int,
+        smoothing_sigma_reference: float,
         smoothing_sigma_floating: float,
-        histogram_n_bins_floating: float,
-        histogram_n_bins_reference: float,
+        histogram_n_bins_floating: int,
+        histogram_n_bins_reference: int,
         debug: bool,
         reset_button,
         check_orientation_button,
@@ -314,7 +314,9 @@ def brainreg_register():
         grid_spacing: int
             Sets the control point grid spacing in x, y & z.
             Smaller grid spacing allows for more local deformations
-             but increases the risk of over-fitting.
+             but increases the risk of over-fitting. Positive
+            values are interpreted as real values in mm, negative values
+            are interpreted as distance in voxels.
         smoothing_sigma_reference: int
             Adds a Gaussian smoothing to the reference image (the one being
             registered), with the sigma defined by the number. Positive
@@ -325,11 +327,11 @@ def brainreg_register():
             registered), with the sigma defined by the number. Positive
             values are interpreted as real values in mm, negative values
             are interpreted as distance in voxels.
-        histogram_n_bins_floating: float
+        histogram_n_bins_floating: int
             Number of bins used for the generation of the histograms used
             for the calculation of Normalized Mutual Information on the
             floating image
-        histogram_n_bins_reference: float
+        histogram_n_bins_reference: int
              Number of bins used for the generation of the histograms used
              for the calculation of Normalized Mutual Information on the
              reference image
@@ -404,9 +406,9 @@ def brainreg_register():
                 freeform_n_steps,
                 freeform_use_n_steps,
                 bending_energy_weight,
-                -grid_spacing,
-                -smoothing_sigma_reference,
-                -smoothing_sigma_floating,
+                grid_spacing,
+                smoothing_sigma_reference,
+                smoothing_sigma_floating,
                 histogram_n_bins_floating,
                 histogram_n_bins_reference,
                 debug=False,
@@ -463,6 +465,7 @@ def brainreg_register():
                 n_free_cpus,
                 save_original_orientation=save_original_orientation,
                 brain_geometry=brain_geometry.value,
+                debug=debug,
             )
 
             logging.info("Calculating volumes of each brain area")

--- a/brainreg/napari/util.py
+++ b/brainreg/napari/util.py
@@ -40,30 +40,52 @@ def initialise_brainreg(atlas_key, data_orientation_key, voxel_sizes):
     )
 
 
-def downsample_and_save_brain(img_layer, scaling):
+def downsample_and_save_brain(
+    img_layer,
+    scaling,
+    anti_aliasing=True,
+    preserve_range=True,
+    mode="constant",
+):
     first_frame_shape = skimage.transform.rescale(
-        img_layer.data[0], scaling[1:2], anti_aliasing=True
+        img_layer.data[0],
+        scaling[1:2],
+        anti_aliasing=anti_aliasing,
+        preserve_range=preserve_range,
+        mode=mode,
     ).shape
     preallocated_array = np.empty(
         (img_layer.data.shape[0], first_frame_shape[0], first_frame_shape[1])
     )
-    print("downsampling data in x, y")
+    print("Downsampling data in x, y")
     for i, img in tqdm(enumerate(img_layer.data)):
         down_xy = skimage.transform.rescale(
-            img, scaling[1:2], anti_aliasing=True
+            img,
+            scaling[1:2],
+            anti_aliasing=anti_aliasing,
+            preserve_range=preserve_range,
+            mode=mode,
         )
         preallocated_array[i] = down_xy
 
     first_ds_frame_shape = skimage.transform.rescale(
-        preallocated_array[:, :, 0], [scaling[0], 1], anti_aliasing=True
+        preallocated_array[:, :, 0],
+        [scaling[0], 1],
+        anti_aliasing=anti_aliasing,
+        preserve_range=preserve_range,
+        mode=mode,
     ).shape
     downsampled_array = np.empty(
         (first_ds_frame_shape[0], first_frame_shape[0], first_frame_shape[1])
     )
-    print("downsampling data in z")
+    print("Downsampling data in z")
     for i, img in tqdm(enumerate(preallocated_array.T)):
         down_xyz = skimage.transform.rescale(
-            img, [1, scaling[0]], anti_aliasing=True
+            img,
+            [1, scaling[0]],
+            anti_aliasing=anti_aliasing,
+            preserve_range=preserve_range,
+            mode=mode,
         )
         downsampled_array[:, :, i] = down_xyz.T
     return downsampled_array


### PR DESCRIPTION
## Description
This PR makes sure the outputs of the napari plugin and CLI are equal. Previously, as highlighted in #192 by @AdrianAriasAbreu, there were differences when running the same data in the napari plugin and CLI. +


- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The plugin and CLI should be two ways of achieving the same thing.

**What does this PR do?**
1. It ensures that the default parameters in the GUI are the same, are are displayed the same as the defaults in the CLI. Previously, some were made negative under the hood. This PR corrects this so everything matches.
2. It downsamples data in the exact same way as [`brainglobe_utils.image_io.load.load_any()`](https://github.com/brainglobe/brainglobe-utils/blob/main/brainglobe_utils/image_io/load.py) (as used by the CLI). 

## References

Closes #192 (I think)

## How has this PR been tested?
The same data has been registered with the plugin and CLI and results confirmed to be the same. Existing tests pass.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?
No, but I noticed some errors in the docs, updated in https://github.com/brainglobe/brainglobe.github.io/pull/170

## Checklist:
- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
