### PR TITLE
make non-conda mac tests use intel chips

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,7 +31,7 @@ jobs:
         include:
         - os: ubuntu-latest
           python-version: "3.11"
-        - os: macos-latest
+        - os: macos-13 # just intel mac here, silicon mac tested with mamba due to niftyreg complications
           python-version: "3.10"
         - os: windows-latest
           python-version: "3.9"
@@ -57,6 +57,7 @@ jobs:
           use-xvfb: true
 
   test-with-conda:
+    # mainly checks conda installation of niftyreg, especially key on Silicon macs
     needs: [linting, manifest]
     name: Test conda-install, on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Non-conda tests were failing due to `macos-latest` now being run on Silicon tests.

**What does this PR do?**
Makes non-conda tests use Intel macs for now, and explains this in comments in the workflow file.

## References
Partial solution to https://github.com/brainglobe/BrainGlobe/issues/63

Related to https://github.com/brainglobe/brainglobe.github.io/issues/171

## How has this PR been tested?

CI runs observed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
