### PR TITLE
Fix hemisphere bug in `check_orientation`

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -560,11 +560,11 @@ def brainreg_register():
         atlas = BrainGlobeAtlas(widget.atlas_key.value.name)
         if brain_geometry.value == "hemisphere_l":
             atlas.reference[
-                atlas.hemispheres == atlas.left_hemisphere_value
+                atlas.hemispheres == atlas.right_hemisphere_value
             ] = 0
         elif brain_geometry.value == "hemisphere_r":
             atlas.reference[
-                atlas.hemispheres == atlas.right_hemisphere_value
+                atlas.hemispheres == atlas.left_hemisphere_value
             ] = 0
         input_orientation = getattr(widget, "data_orientation").value
         data = getattr(widget, "img_layer").value.data

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -116,6 +116,22 @@ def test_orientation_check(
     # run again and check previous output was deleted properly
     run_and_check_orientation_check(widget, viewer, brain_layer, atlas)
 
+    # "allen_mouse_50um" orientation is ASR
+    # so S-I projection will have origin AR
+    # so the columns 0 to half should be filled with zeros
+    # if we only want to register to the left hemisphere
+    # LR axis is 228
+    widget.brain_geometry.value = widget.brain_geometry.annotation[
+        "Left hemisphere"
+    ]
+    run_and_check_orientation_check(widget, viewer, brain_layer, atlas)
+    ar_projection = viewer.layers["Ref. proj. 1"].data
+    import numpy as np
+
+    assert ar_projection.shape[1] // 2 == 114
+    assert np.all(ar_projection[:, 114] == 0)
+    assert not np.all(ar_projection[:, 115] == 0)
+
 
 def run_and_check_orientation_check(widget, viewer, brain_layer, atlas):
     widget.check_orientation_button.clicked()


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`check_orientation` gave false information when working with hemispheres

**What does this PR do?**

Ensures `check_orientation` info is displayed correctly when working with hemispheres, and adds a test for this too (the test(s) could be more exhaustive, but hopefully sufficient in their current state, given `brainreg` development beyond maintenance not on our roadmap at the moment)

## References

Closes #200

## How has this PR been tested?

* manual inspection by @IgorTatarnikov and I
* new test added
* I have locally checked that the new test failed before I made the bugfix commit

## Is this a breaking change?

No (apart from fixing faulty behaviour).

## Does this PR require an update to the documentation?

Maybe we should specify better the point of view of the check_orientation, and understand that better in the first place - to be tackled in https://github.com/brainglobe/brainglobe.github.io/issues/210

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ \ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
