### PR TITLE
Mark failing napari tests as xfail

### DIFF
--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -78,7 +78,9 @@ def test_workflow(make_napari_viewer, tmp_path):
     assert boundaries.name == "Boundaries"
 
 
-@pytest.mark.xfail(reason="See https://github.com/brainglobe/cellfinder/issues/443")
+@pytest.mark.xfail(
+    reason="See https://github.com/brainglobe/cellfinder/issues/443"
+)
 def test_orientation_check(
     make_napari_viewer, tmp_path, atlas_choice="allen_mouse_50um"
 ):
@@ -168,7 +170,9 @@ def check_orientation_output(viewer, brain_layer, atlas):
     assert viewer.layers[3].data.shape == (atlas.shape[0], atlas.shape[1])
 
 
-@pytest.mark.xfail(reason="See https://github.com/brainglobe/cellfinder/issues/443")
+@pytest.mark.xfail(
+    reason="See https://github.com/brainglobe/cellfinder/issues/443"
+)
 def test_add_layers_errors(tmp_path, make_napari_viewer):
     """
     Check that an error is raised if registration metadata isn't present when

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -80,7 +80,7 @@ def test_workflow(make_napari_viewer, tmp_path):
 
 @pytest.mark.xfail(
     reason="See https://github.com/brainglobe/cellfinder/issues/443",
-    raises=AssertionError
+    raises=AssertionError,
 )
 def test_orientation_check(
     make_napari_viewer, tmp_path, atlas_choice="allen_mouse_50um"
@@ -173,7 +173,7 @@ def check_orientation_output(viewer, brain_layer, atlas):
 
 @pytest.mark.xfail(
     reason="See https://github.com/brainglobe/cellfinder/issues/443",
-    raises=AssertionError
+    raises=AssertionError,
 )
 def test_add_layers_errors(tmp_path, make_napari_viewer):
     """

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -79,7 +79,8 @@ def test_workflow(make_napari_viewer, tmp_path):
 
 
 @pytest.mark.xfail(
-    reason="See https://github.com/brainglobe/cellfinder/issues/443"
+    reason="See https://github.com/brainglobe/cellfinder/issues/443",
+    raises=AssertionError
 )
 def test_orientation_check(
     make_napari_viewer, tmp_path, atlas_choice="allen_mouse_50um"

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -171,7 +171,8 @@ def check_orientation_output(viewer, brain_layer, atlas):
 
 
 @pytest.mark.xfail(
-    reason="See https://github.com/brainglobe/cellfinder/issues/443"
+    reason="See https://github.com/brainglobe/cellfinder/issues/443",
+    raises=AssertionError
 )
 def test_add_layers_errors(tmp_path, make_napari_viewer):
     """

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -78,6 +78,7 @@ def test_workflow(make_napari_viewer, tmp_path):
     assert boundaries.name == "Boundaries"
 
 
+@pytest.mark.xfail(reason="See https://github.com/brainglobe/cellfinder/issues/443")
 def test_orientation_check(
     make_napari_viewer, tmp_path, atlas_choice="allen_mouse_50um"
 ):
@@ -167,6 +168,7 @@ def check_orientation_output(viewer, brain_layer, atlas):
     assert viewer.layers[3].data.shape == (atlas.shape[0], atlas.shape[1])
 
 
+@pytest.mark.xfail(reason="See https://github.com/brainglobe/cellfinder/issues/443")
 def test_add_layers_errors(tmp_path, make_napari_viewer):
     """
     Check that an error is raised if registration metadata isn't present when


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Tests are failing due to an error in the teardown of the `make_napari_viewer` fixture.

**What does this PR do?**
Marks tests with xfail.

## References
https://github.com/brainglobe/cellfinder/issues/443


## How has this PR been tested?
All tests pass locally in a fresh environment.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
