### PR TITLE
Update Python versions to adhere to SPEC 0 and remove Intel testing on macOS

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,14 +30,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run across a mixture of Python versions and operating systems
+        # Run all supported Python versions on linux
+        os: [ ubuntu-latest ]
+        python-version: [ "3.11", "3.12", "3.13" ]
+        # Include one windows and two macOS (intel based and arm based) runs
         include:
-        - os: ubuntu-latest
-          python-version: "3.12"
-        - os: macos-13 # just intel mac here, silicon mac tested with mamba due to niftyreg complications
-          python-version: "3.11"
-        - os: windows-latest
-          python-version: "3.10"
+          # silicon mac tested with mamba due to niftyreg complications
+          - os: windows-latest
+            python-version: "3.13"
 
     steps:
       - name: Cache brainglobe directory
@@ -90,7 +90,7 @@ jobs:
           init-shell: bash
           environment-name: niftyreg-env
           create-args: >-
-            python=3.12
+            python=3.13silicon mac tested with mamba due to niftyreg complications
             setuptools
             setuptools_scm
             wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: napari",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "brainglobe-atlasapi>=2.0.1",
     "brainglobe-space>=1.0.0",
@@ -87,7 +87,7 @@ addopts = "--cov=brainreg"
 [tool.black]
 line-length = 79
 skip-string-normalization = false
-target-version = ['py310','py311', 'py312']
+target-version = ['py311','py312', 'py313']
 
 [tool.ruff]
 line-length = 79
@@ -98,14 +98,14 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{310,311,312}
+envlist = py{311,312,313}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 extras =


### PR DESCRIPTION
I also standardised the CI config a bit. 