### PR TITLE
Pin napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ napari = [
     "brainglobe-segmentation >= 1.0.0",
     "magicgui",
     "napari-plugin-engine >= 0.1.4",
-    "napari[pyqt5]",
+    "napari[pyqt5]<0.6.0",
     "pooch>1",                          # For sample data
     "qtpy",
 ]
@@ -42,7 +42,7 @@ dev = [
     "black",
     "check-manifest",
     "gitpython",
-    "napari[pyqt5]",
+    "napari[pyqt5]<0.6.0",
     "pre-commit",
     "pytest-cov",
     "pytest-qt",


### PR DESCRIPTION
Pinning napari<0.6.0. Can't instantiate a label layer from an array of uint32 dtype in napari==0.6.0.