### PR TITLE
[Feature] Specify units for voxel sizes in napari plugin

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -148,16 +148,19 @@ def brainreg_register():
             value=DEFAULT_PARAMETERS["z_pixel_um"],
             label="Voxel size (z, um)",
             step=0.1,
+            tooltip="Voxel size in the z-dimension (micrometers).",
         ),
         y_pixel_um=dict(
             value=DEFAULT_PARAMETERS["y_pixel_um"],
             label="Voxel size (y, um)",
             step=0.1,
+            tooltip="Voxel size in the y-dimension (micrometers).",
         ),
         x_pixel_um=dict(
             value=DEFAULT_PARAMETERS["x_pixel_um"],
             label="Voxel size (x, um)",
             step=0.1,
+            tooltip="Voxel size in the x-dimension (micrometers).",
         ),
         data_orientation=dict(
             value=DEFAULT_PARAMETERS["data_orientation"],

--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -146,17 +146,17 @@ def brainreg_register():
         ),
         z_pixel_um=dict(
             value=DEFAULT_PARAMETERS["z_pixel_um"],
-            label="Voxel size (z)",
+            label="Voxel size (z, um)",
             step=0.1,
         ),
         y_pixel_um=dict(
             value=DEFAULT_PARAMETERS["y_pixel_um"],
-            label="Voxel size (y)",
+            label="Voxel size (y, um)",
             step=0.1,
         ),
         x_pixel_um=dict(
             value=DEFAULT_PARAMETERS["x_pixel_um"],
-            label="Voxel size (x)",
+            label="Voxel size (x, um)",
             step=0.1,
         ),
         data_orientation=dict(


### PR DESCRIPTION
Enhance user experience by including units in voxel size labels and providing tooltips for voxel size parameters in the brain registration function.

closes #223