### PR TITLE
Exclude napari 0.6.0, enforce >= 0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ napari = [
     "brainglobe-segmentation >= 1.0.0",
     "magicgui",
     "napari-plugin-engine >= 0.1.4",
-    "napari[pyqt5]<0.6.0",
+    "napari[pyqt5]>=0.5 !=0.6.0",
     "pooch>1",                          # For sample data
     "qtpy",
 ]


### PR DESCRIPTION
Reverting napari pin and standardising minimum napari version across BrainGlobe.