### PR TITLE
Run scheduled tests against napari main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -59,6 +59,16 @@ jobs:
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
           use-xvfb: true
 
+      # Run tests on napari main if this is a scheduled run
+      - name: Run tests on napari main
+        if: github.event_name == 'schedule'
+        uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          use-xvfb: true
+          tox-args: '-e napari-dev'
+
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'
         uses: ravsamhq/notify-slack-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{311,312,313}
+envlist = py{311,312,313}, napari-dev
 isolated_build = True
 
 [gh-actions]
@@ -120,4 +120,6 @@ passenv =
     XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
+deps =
+    napari-dev: git+https://github.com/napari/napari
 """


### PR DESCRIPTION
Adds an extra run of the neuroinformatics/actions/test with napari installed from main. This action will only run during the weekly cron job.