### PR TITLE
Ensures boundaries layer is displayed in `napari`

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -84,7 +84,9 @@ def add_registered_image_layers(
         if layer[1]["name"] == metadata["atlas"]:
             labels_ind = idx
 
-    boundaries = viewer.add_layer(napari.layers.Layer.create(*layers[boundaries_ind]))
+    boundaries = viewer.add_layer(
+        napari.layers.Layer.create(*layers[boundaries_ind])
+    )
     labels = viewer.add_layer(napari.layers.Layer.create(*layers[labels_ind]))
     return boundaries, labels
 

--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -74,8 +74,18 @@ def add_registered_image_layers(
             f"'brainreg.json' file not found in {registration_directory}"
         )
 
-    boundaries = viewer.add_layer(napari.layers.Layer.create(*layers[0]))
-    labels = viewer.add_layer(napari.layers.Layer.create(*layers[1]))
+    # Set expected default values
+    boundaries_ind = 2
+    labels_ind = 1
+
+    for idx, layer in enumerate(layers):
+        if layer[1]["name"] == "Boundaries":
+            boundaries_ind = idx
+        if layer[1]["name"] == metadata["atlas"]:
+            labels_ind = idx
+
+    boundaries = viewer.add_layer(napari.layers.Layer.create(*layers[boundaries_ind]))
+    labels = viewer.add_layer(napari.layers.Layer.create(*layers[labels_ind]))
     return boundaries, labels
 
 

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -63,9 +63,8 @@ def test_workflow(make_napari_viewer, tmp_path):
     # Check that layers have been added
     assert len(viewer.layers) == 3
     # Check layers have expected type/name
-    labels = viewer.layers[1]
+    labels = viewer.layers["example_mouse_100um"]
     assert isinstance(labels, napari.layers.Labels)
-    assert labels.name == "example_mouse_100um"
     for key in ["orientation", "atlas"]:
         # There are lots of other keys in the metadata, but just check
         # for a couple here.
@@ -73,9 +72,8 @@ def test_workflow(make_napari_viewer, tmp_path):
             key in labels.metadata
         ), f"Missing key '{key}' from labels metadata"
 
-    boundaries = viewer.layers[2]
+    boundaries = viewer.layers["Boundaries"]
     assert isinstance(boundaries, napari.layers.Image)
-    assert boundaries.name == "Boundaries"
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
See #254 

**What does this PR do?**
Removes hard coded indexes that assume the order of layers returned by [`load_registration`](https://github.com/brainglobe/brainglobe-napari-io/blob/6da22d5b2c793f3fd012800889ee42ac3f0b5a83/brainglobe_napari_io/brainmapper/brainmapper_reader_dir.py#L151-L162).

This PR sets the "expected" default, but adds logic to double check the layers are correct.
The test now fetches the layers by name, if the layers aren't present the test will error.

## References
closes #254 

## How has this PR been tested?
All tests pass again.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
