### PR TITLE
Update `napari` dependencies

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -104,7 +104,7 @@ jobs:
             wheel
 
       # Helps set up VTK with a headless display
-      - uses: pyvista/setup-headless-display-action@v3
+      - uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4
         with:
           qt: true
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,7 +48,7 @@ jobs:
           key: atlases
 
       # Helps set up VTK with a headless display
-      - uses: pyvista/setup-headless-display-action@v3
+      - uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4
         with:
           qt: true
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -103,6 +103,11 @@ jobs:
             setuptools_scm
             wheel
 
+      # Helps set up VTK with a headless display
+      - uses: pyvista/setup-headless-display-action@v3
+        with:
+          qt: true
+
       - name: Install package into environment
         shell: bash -el {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,24 +20,22 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "brainglobe-atlasapi>=2.0.1",
+    "brainglobe-napari-io>=0.3.2",
+    "brainglobe-segmentation>=1.0.0",
     "brainglobe-space>=1.0.0",
     "brainglobe-utils>=0.10.0",
     "fancylog>=0.6.0",
+    "magicgui",
     "numpy",
+    "pooch>1",                          # For sample data
+    "qtpy",
     "scikit-image>=0.24.0",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-napari = [
-    "brainglobe-napari-io >=0.3.2",
-    "brainglobe-segmentation >= 1.0.0",
-    "magicgui",
-    "napari-plugin-engine >= 0.1.4",
-    "napari[pyqt5]>=0.6.5",
-    "pooch>1",                          # For sample data
-    "qtpy",
-]
+napari = ["napari[all]>=0.6.5"]
+
 dev = [
     "brainreg[napari]",
     "black",


### PR DESCRIPTION
Updates dependencies such that two conditions are satisfied:

- The base dependencies don't specify a backend for `napari`
- `brainreg` is installable via the `napari` GUI (all dependencies required to open the plugin are in the base dependencies)
- Retains an optional napari group to allow an easy one command install for fresh environments.

Closes #274 

Had to add pyvista/setup-headless-display-action before the conda tests now that `pyqt6` is being used instead of `pyqt5`.