### PR TITLE
`brainglobe-atlasapi` V3 compatibility

### DIFF
--- a/brainreg/napari/register.py
+++ b/brainreg/napari/register.py
@@ -9,7 +9,7 @@ import brainglobe_space as bg
 import napari
 import numpy as np
 from brainglobe_atlasapi import BrainGlobeAtlas
-from brainglobe_atlasapi.list_atlases import descriptors, utils
+from brainglobe_atlasapi.list_atlases import get_all_atlases_lastversions
 from brainglobe_napari_io.brainmapper.brainmapper_reader_dir import (
     load_registration,
 )
@@ -41,11 +41,7 @@ def get_available_atlases():
     Get the available brainglobe atlases
     :return: Dict of available atlases (["name":version])
     """
-    available_atlases = utils.conf_from_url(
-        descriptors.remote_url_base.format("last_versions.conf")
-    )
-    available_atlases = dict(available_atlases["atlases"])
-    return available_atlases
+    return get_all_atlases_lastversions()
 
 
 def add_registered_image_layers(

--- a/tests/test_brainreg_napari.py
+++ b/tests/test_brainreg_napari.py
@@ -55,6 +55,9 @@ def test_workflow(make_napari_viewer, tmp_path):
         pixel_widget = getattr(widget, f"{dim}_pixel_um")
         pixel_widget.value = brain_layer.metadata["voxel_size"][i]
 
+    # Set atlas to example_mouse_100um
+    widget.atlas_key.value = widget.atlas_key.annotation["example_mouse_100um"]
+
     assert len(viewer.layers) == 1
 
     # Run registration


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
See #280 

**What does this PR do?**
Change the way available atlases are fetched for the dropdown to use `get_all_atlases_last_versions()`.
Sets `aiobotocore` and `botocore` debugging level to INFO.
Ensures the `example_mouse_100um` is used for testing.

## References
Closes #280 

## How has this PR been tested?
Tested locally with `brainglobe-atlasapi==3.0.0rc1` and `brainglobe-atlasapi==2.3.1`. All tests pass.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
